### PR TITLE
[ODM-11738] Transfer wipeStudy to MetainfoEditorLibrary

### DIFF
--- a/jupyter_notebooks/sharing-exporting-deleting.ipynb
+++ b/jupyter_notebooks/sharing-exporting-deleting.ipynb
@@ -183,7 +183,7 @@
    ],
    "source": [
     "object_to_delete = 'GSF015445'\n",
-    "url_delete_object = app_endpoint + 'arvados-importer/wipeStudy'\n",
+    "url_delete_object = app_endpoint + 'study-metainfo-editor/wipeStudy'\n",
     "s.post(url=url_delete_object, json=[object_to_delete])"
    ]
   },

--- a/scripts/import/delete_study_via_api.py
+++ b/scripts/import/delete_study_via_api.py
@@ -21,7 +21,7 @@ def delete_study(study_accession, srv, token):
     url_authenticate = app_endpoint + 'signin/authenticateByApiToken'
     s = requests.Session()
     s.post(url_authenticate, json=[token])
-    url_delete_object = app_endpoint + 'arvados-importer/wipeStudy'
+    url_delete_object = app_endpoint + 'study-metainfo-editor/wipeStudy'
     header = {'Genestack-API-Token': token}
     response = s.post(url=url_delete_object, json=[study_accession], headers=header)
     print(response.status_code)


### PR DESCRIPTION
[ODM-11738] Transfer wipeStudy to MetainfoEditorLibrary

- replaced `arvados-importer` with `study-metainfo-editor`

Linked PRs:

- https://github.com/genestack/sdk/pull/467
- https://github.com/genestack/ui/pull/83
- https://github.com/genestack/unified/pull/3345
- https://github.com/genestack/functional-tests/pull/562

[ODM-11738]: https://genestack.atlassian.net/browse/ODM-11738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ